### PR TITLE
Update cesium-dashboard.yaml

### DIFF
--- a/cesium-dashboard.yaml
+++ b/cesium-dashboard.yaml
@@ -18,6 +18,9 @@ spec:
         image: ghcr.io/forumviriumhelsinki/cesium-dashboard:latest
         ports:
         - containerPort: 4173
+        envFrom:
+        - configMapRef:
+          name: cesium-dashboard-config
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Get environment variables from a configmap so that TILE_BASE_URL can be easily configured in different environments.