### PR TITLE
feat: move VITE_TILE_BASE_URL to build-arg in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM --platform=linux/amd64 node:21-alpine
 
+ARG VITE_TILE_BASE_URL="https://dl2sa.blob.core.windows.net/public3d/katukuntotieto"
+
 WORKDIR /app
 
 COPY . .

--- a/cesium-dashboard.yaml
+++ b/cesium-dashboard.yaml
@@ -18,16 +18,6 @@ spec:
         image: ghcr.io/forumviriumhelsinki/cesium-dashboard:latest
         ports:
         - containerPort: 4173
-        envFrom:
-        - configMapRef:
-            name: cesium-dashboard-config
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cesium-dashboard-config
-data:
-  VITE_TILE_BASE_URL: "https://dl2sa.blob.core.windows.net/public3d/katukuntotieto"
 ---
 apiVersion: v1
 kind: Service

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,5 @@ services:
       context: .
     environment:
       NODE_ENV: production
-      # VITE_TILE_BASE_URL: "https://hel-roadcondition.s3.eu-north-1.amazonaws.com/3dtiles"
-      VITE_TILE_BASE_URL: "https://dl2sa.blob.core.windows.net/public3d/katukuntotieto"
     ports:
       - 4173:4173


### PR DESCRIPTION
The value is statically replaced by Vite at build time so fetching it from an env variable at runtime doesn't work.

The arg can be used when building the container image to override the default.