### PR TITLE
feat(ci): adopt reusable auto-fix, review, and conventional commits workflows

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -1,0 +1,24 @@
+name: Auto-fix CI Failures
+
+on:
+  workflow_run:
+    workflows: ["cesium-dashboard-image"]
+    types: [completed]
+
+jobs:
+  auto-fix:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      !startsWith(github.event.workflow_run.head_commit.message, 'fix(auto):') &&
+      (github.event.workflow_run.actor.type != 'Bot' ||
+       github.event.workflow_run.actor.login == 'claude[bot]' ||
+       github.event.workflow_run.actor.login == 'claude') &&
+      github.event.workflow_run.head_branch != 'main'
+    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-auto-fix.yml@main
+    with:
+      branch: ${{ github.event.workflow_run.head_branch }}
+      run_id: ${{ github.event.workflow_run.id }}
+      workflow_name: ${{ github.event.workflow_run.name }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,11 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-claude-review.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -1,0 +1,9 @@
+name: Enforce Conventional Commits
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  conventional-commits:
+    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-enforce-conventional-commits.yml@main


### PR DESCRIPTION
## Summary

- Add `auto-fix.yml` — auto-fix CI failures via reusable workflow (watches: "cesium-dashboard-image")
- Add `enforce-conventional-commits.yml` — auto-fix PR titles to conventional commits
- Add `claude-review.yml` — automated PR review with Claude Code
Fixes ForumViriumHelsinki/.github#17

## Test plan

- [ ] Verify workflows appear in Actions tab after merge
- [ ] Create a test PR to confirm conventional commits and review trigger
- [ ] Trigger a CI failure on a branch to verify auto-fix

Generated with [Claude Code](https://claude.com/claude-code)